### PR TITLE
Rename library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# flow-typecheck
+# flowcheck
 
 ![](http://g.recordit.co/JJcGkIblZj.gif)
 
@@ -13,7 +13,7 @@ The idea is this:
 
 ```js
 /*
- * @typecheck(base, expression) {
+ * @flowcheck(base, expression) {
  *   pow(base, expression) === Math.pow(base, expression)
  * }
  */

--- a/fixture.js
+++ b/fixture.js
@@ -1,5 +1,5 @@
 /*
- * @testcheck(bar) {
+ * @flowcheck(bar) {
  *   return foo(bar) === bar;
  * }
  */
@@ -10,7 +10,7 @@ function foo(bar:number) {
 
 let nonPureCounter = 0;
 /*
- * @testcheck(arg1) {
+ * @flowcheck(arg1) {
  *   return baz(arg1) === baz(arg1);
  * }
  */

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "FlowTestCheck",
+  "name": "flowcheck",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/src/__tests__/PluginTest.js
+++ b/src/__tests__/PluginTest.js
@@ -17,7 +17,6 @@ const results = folders.map(folder => {
   let parsedCode;
   let didThrow = false;
 
-
   if (shouldThrow) {
     try {
       parsedCode = transformCode(actualPretransform);

--- a/src/__tests__/fixtures/export-default-function/index.js
+++ b/src/__tests__/fixtures/export-default-function/index.js
@@ -9,7 +9,7 @@
  */
 
 /*
- * @testcheck(bar) {
+ * @flowcheck(bar) {
  *   return foo(bar) === bar;
  * }
  */

--- a/src/__tests__/fixtures/exported-function/index.js
+++ b/src/__tests__/fixtures/exported-function/index.js
@@ -8,7 +8,7 @@
  */
 
 /*
- * @testcheck(bar) {
+ * @flowcheck(bar) {
  *   return foo(bar) === bar;
  * }
  */

--- a/src/__tests__/fixtures/function/index.js
+++ b/src/__tests__/fixtures/function/index.js
@@ -5,7 +5,7 @@
 
 
 /*
- * @testcheck(bar) {
+ * @flowcheck(bar) {
  *   return foo(bar) === bar;
  * }
  */

--- a/src/babel-plugin/__tests__/parseTestcheckComments--tests.js
+++ b/src/babel-plugin/__tests__/parseTestcheckComments--tests.js
@@ -1,24 +1,24 @@
-const _parse = require.requireActual('../parseTestcheckComments');
+const _parse = require.requireActual('../parseFlowcheckComments');
 
-function parseTestcheckComments(value) {
+function parseflowcheckComments(value) {
   return _parse({
     value,
   });
 }
 
 const expectation =
-  'function testcheck() {' +
+  'function flowcheck() {' +
   '}';
 
 describe('parsing comments', () => {
   it('removes the and /* style comments */', () => {
     const comments =
       '/*' +
-       '* @testcheck() {' +
+       '* @flowcheck() {' +
        '* }' +
        '*/';
 
-    const parsed = parseTestcheckComments(comments);
+    const parsed = parseflowcheckComments(comments);
 
     expect(parsed).toBe(expectation);
   });
@@ -26,60 +26,60 @@ describe('parsing comments', () => {
   it('removes the /*style*/ with bad spacing', () => {
     const comments =
       '/*' +
-       '*@testcheck() {' +
+       '*@flowcheck() {' +
        '*}' +
        '*/';
 
-    const parsed = parseTestcheckComments(comments);
+    const parsed = parseflowcheckComments(comments);
 
     expect(parsed).toBe(expectation);
   });
 
   it('removes the // style comments', () => {
     const comments =
-      '// @testcheck() {' +
+      '// @flowcheck() {' +
       '// }';
 
-    const parsed = parseTestcheckComments(comments);
+    const parsed = parseflowcheckComments(comments);
 
     expect(parsed).toBe(expectation);
   });
 
   it('removes the // with bad spacing', () => {
     const comments =
-      '//@testcheck() {' +
+      '//@flowcheck() {' +
       '//}';
 
-    const parsed = parseTestcheckComments(comments);
+    const parsed = parseflowcheckComments(comments);
 
     expect(parsed).toBe(expectation);
   });
 
 
-  it('ignores the extra comments leading the testcheck directive', () => {
+  it('ignores the extra comments leading the flowcheck directive', () => {
     const comments =
       '/*' +
        '* lorem ipsum bull shit' +
-       '* @testcheck() {' +
+       '* @flowcheck() {' +
        '* }' +
        '*/';
 
-    const parsed = parseTestcheckComments(comments);
+    const parsed = parseflowcheckComments(comments);
 
     expect(parsed).toBe(expectation);
   });
 
 
-  it('throws if there are extra comments trailing the testcheck directive', () => {
+  it('throws if there are extra comments trailing the flowcheck directive', () => {
     const comments =
       '/*' +
-       '* @testcheck() {' +
+       '* @flowcheck() {' +
        '* }' +
        '* lorem ipsum bull shit' +
        '*/';
 
     expect(
-      () => parseTestcheckComments(comments)
+      () => parseflowcheckComments(comments)
     ).toThrow();
   });
 });

--- a/src/babel-plugin/index.js
+++ b/src/babel-plugin/index.js
@@ -2,11 +2,15 @@
 
 const addTestcheckCall = require('./addTestcheckCall');
 const decypherParamTypes = require('./decypherParamTypes');
-const parseTestcheckComments = require('./parseTestcheckComments');
+const parseFlowcheckComments = require('./parseFlowcheckComments');
 const t = require('babel-types');
 
 module.exports = function flowParser() {
-  const TESTCHECK_DIRECTIVE = '@testcheck';
+  // I want the directive look up to be @flowcheck
+  // but `babel-plugin-transform-flow-strip` removes the @flow part
+  // of the directive before I get it..
+  // Maybe we can submit a PR to them to only get @flow\n
+  const FLOWCHECK_DIRECTIVE = 'check\(';
 
   return {
     visitor: {
@@ -39,9 +43,9 @@ module.exports = function flowParser() {
           if (!comments) return;
 
           comments.forEach(function checkForDirective(comment) {
-            if (comment.value.search(TESTCHECK_DIRECTIVE) !== -1) {
+            if (comment.value.indexOf(FLOWCHECK_DIRECTIVE) >= 0) {
               state.set('wantsTestcheck', true);
-              state.set('parsedCommentBlock', parseTestcheckComments(comment));
+              state.set('parsedCommentBlock', parseFlowcheckComments(comment));
             }
           });
 
@@ -64,7 +68,7 @@ module.exports = function flowParser() {
 
 
         comments.forEach(function checkForDirective(comment) {
-          if (comment.value.search(TESTCHECK_DIRECTIVE) !== -1) {
+          if (comment.value.indexOf(FLOWCHECK_DIRECTIVE) >= 0) {
             throw new Error(
               'Flowcheck: Unsupported syntax. Flowcheck does not currently support comments on exported functions'
             );

--- a/src/babel-plugin/parseFlowcheckComments.js
+++ b/src/babel-plugin/parseFlowcheckComments.js
@@ -14,19 +14,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * @providesModule parseTestcheckComment
+ * @providesModule parseFlowcheckComment
  * @flow
  */
 
 "use strict";
 
-module.exports = function parseTestcheckComment(comment) {
+module.exports = function parseFlowcheckComment(comment) {
   let value = comment.value;
+  const FLOWCHECK_DIRECTIVE = 'check(';
 
-  const testcheckDirectiveStartIndex = value.search('@testcheck');
+  const flowcheckDirectiveStartIndex = value.indexOf(FLOWCHECK_DIRECTIVE);
 
-  // trim off any comments prior to testcheck directive
-  value = value.substring(testcheckDirectiveStartIndex, value.length);
+  // trim off any comments prior to flowcheck directive
+  value = value.substring(flowcheckDirectiveStartIndex, value.length);
 
   /*
    * This is for comments of the /* style
@@ -44,7 +45,7 @@ module.exports = function parseTestcheckComment(comment) {
   //or this
   value = value.replace(/\/\/\s?/g, '');
 
-  const fn = value.replace('@testcheck', 'function testcheck');
+  const fn = value.replace(FLOWCHECK_DIRECTIVE, 'function flowcheck(');
 
   // make sure code is good, throw if not
   // some parsing error occured
@@ -53,7 +54,7 @@ module.exports = function parseTestcheckComment(comment) {
   } catch(e) {
     throw new Error(
       'Flowcheck parsing error\n' +
-      '  Parsing the @testcheck comments encountered an error.'
+      '  Parsing the @flowcheck comments encountered an error.'
     );
   }
 

--- a/src/findFiles.js
+++ b/src/findFiles.js
@@ -19,12 +19,18 @@
  * @flow
  */
 
+"use strict";
+
 const glob = require('glob');
 const fs = require('fs');
 
 module.exports = function findFiles(cb) {
-  console.log('  searching for @testchecks...'.yellow);
-  glob('**/*.js', { ignore: '**node_modules/**/*.js' }, (err, files) => {
+  console.log('  searching for @flowcheck\'s...'.yellow);
+
+  let globPath = '**/*.js';
+  globPath = '**/fixture.js'; // only for now until we actually build the cli
+
+  glob(globPath, { ignore: ['**node_modules/**/*.js'] }, (err, files) => {
     if (err) {
       throw new Error(err);
     }
@@ -37,10 +43,10 @@ module.exports = function findFiles(cb) {
     });
 
     const filteredForMatches = codeAndPath.filter(
-      o => o.code.search(/\@testcheck\(/) !== -1
+      o => o.code.search(/\@flowcheck\(/) !== -1
     );
 
-    console.log(`  Found ${filteredForMatches.length} file with @testcheck directives`.yellow);
+    console.log(`  Found ${filteredForMatches.length} file with @flowcheck directives`.yellow);
 
     cb(filteredForMatches);
   });

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 
 require('colors');
 
-console.log('@flow-testcheck engaged!'.rainbow);
+console.log('@flowcheck engaged!'.rainbow);
 
 const parseStringifiedCode = require('./parseStringifiedCode');
 const logResults = require('./logResults');

--- a/src/logResults.js
+++ b/src/logResults.js
@@ -33,12 +33,12 @@ module.exports = function logResults(results) {
 };
 
 function logSuccess(name) {
-  console.log(`\nSuccess: Function "${name}" passed the testcheck!`.green);
+  console.log(`\nSuccess: Function "${name}" passed the flowcheck!`.green);
 }
 
 function logFailure(result) {
   const resultData = result.results;
-  console.log(`\nFailure: Function "${result.name}" failed the testcheck!`.red);
+  console.log(`\nFailure: Function "${result.name}" failed the flowcheck!`.red);
   console.log('  Arguments that triggered Failure:'.cyan, resultData.fail + ''.yellow);
   console.log(`\n  - FailingSize: ${resultData['failing-size']}`.cyan);
   console.log(`  - NumberOfTests: ${resultData['num-tests']}`.cyan);

--- a/src/parseStringifiedCode.js
+++ b/src/parseStringifiedCode.js
@@ -19,7 +19,7 @@
  */
 
 const babel = require('babel-core');
-const testcheckParser = require('./babel-plugin');
+const flowcheckParser = require('./babel-plugin');
 const es2015 = require('babel-preset-es2015');
 const stripFlow = require('babel-plugin-transform-flow-strip-types');
 const syntaxFlow = require('babel-plugin-syntax-flow');
@@ -28,11 +28,11 @@ const syntaxFlow = require('babel-plugin-syntax-flow');
 module.exports = function parseStringifiedCode(code) {
   return babel.transform(code, {
     presets: [
-      es2015
+      es2015,
     ],
     plugins: [
       syntaxFlow,
-      testcheckParser,
+      flowcheckParser,
       stripFlow,
     ],
   }).code;


### PR DESCRIPTION
Addresses #6.

We have to do some ugly pattern matching because https://github.com/babel/babel/blob/master/packages/babel-plugin-transform-flow-strip-types/src/index.js strips the word `@flow` from the comments before we get it.. which sucks

hopefully we can work with the babel team to make this cleaner.
